### PR TITLE
Do not create session when user does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ application-*.properties
 
 # generated log record schemas
 src/main/resources/log-schemas/*-gen.json
-.mirrord/mirrord.json
+.mirrord/


### PR DESCRIPTION
There might be situation that user is authenticated using OAuth2 provider, however user does not exist in the platform. In this case, we need to invalidate session and security context.