### PR TITLE
Fix adding same certificate to inventory from certificate extension in parallel certificate validations

### DIFF
--- a/src/main/java/com/czertainly/core/dao/entity/Certificate.java
+++ b/src/main/java/com/czertainly/core/dao/entity/Certificate.java
@@ -97,7 +97,7 @@ public class Certificate extends UniquelyIdentifiedAndAudited implements Seriali
     @Enumerated(EnumType.STRING)
     private CertificateValidationStatus validationStatus;
 
-    @Column(name = "fingerprint")
+    @Column(name = "fingerprint", unique = true)
     private String fingerprint;
 
     @Column(name = "public_key_fingerprint")

--- a/src/main/java/com/czertainly/core/dao/entity/CertificateContent.java
+++ b/src/main/java/com/czertainly/core/dao/entity/CertificateContent.java
@@ -3,6 +3,7 @@ package com.czertainly.core.dao.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.proxy.HibernateProxy;
 
 import java.io.Serializable;
@@ -20,11 +21,12 @@ public class CertificateContent implements Serializable {
 
     @Id
     @Column(name = "id")
+    @ColumnDefault("nextval('certificate_content_id_seq'::regclass)")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "certificate_content_seq")
     @SequenceGenerator(name = "certificate_content_seq", sequenceName = "certificate_content_id_seq", allocationSize = 1)
     private Long id;
 
-    @Column(name = "fingerprint")
+    @Column(name = "fingerprint", unique = true)
     private String fingerprint;
 
     @Column(name = "content", length = Integer.MAX_VALUE)

--- a/src/main/java/com/czertainly/core/dao/repository/CertificateContentRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/CertificateContentRepository.java
@@ -5,19 +5,11 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface CertificateContentRepository extends SecurityFilterRepository<CertificateContent, Long> {
 
     CertificateContent findByFingerprint(String thumbprint);
     CertificateContent findByContent(String content);
-
-    @Query("SELECT c FROM CertificateContent c " +
-            "LEFT JOIN Certificate t1 ON c.id= t1.certificateContentId " +
-            "LEFT JOIN DiscoveryCertificate t2 ON c.id = t2.certificateContentId " +
-            "WHERE t1 IS NULL AND t2 IS NULL")
-    List<CertificateContent> findCertificateContentNotUsed();
 
     @Modifying
     @Query("""
@@ -27,5 +19,14 @@ public interface CertificateContentRepository extends SecurityFilterRepository<C
             	NOT EXISTS (SELECT 1 FROM DiscoveryCertificate dc WHERE dc.certificateContentId = cc.id)
             """)
     int deleteUnusedCertificateContents();
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO {h-schema}certificate_content (fingerprint,content)
+            VALUES (?1, ?2)
+            ON CONFLICT (fingerprint)
+            DO NOTHING
+            """, nativeQuery = true)
+    int insertWithFingerprintConflictResolve(String fingerprint, String content);
 
 }

--- a/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
+++ b/src/main/java/com/czertainly/core/dao/repository/CertificateRepository.java
@@ -86,4 +86,30 @@ public interface CertificateRepository extends SecurityFilterRepository<Certific
     @Modifying
     @Query("UPDATE Certificate c SET c.keyUuid = ?1 WHERE c.uuid IN ?2")
     void setKeyUuid(UUID keyUuid, List<UUID> uuids);
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO {h-schema}certificate (
+            uuid, i_author, i_cre, i_upd, ra_profile_uuid,certificate_content_id,
+            certificate_request_uuid,source_certificate_uuid,issuer_certificate_uuid,certificate_type,
+            state,validation_status,certificate_validation_result,status_validation_timestamp,
+            compliance_status,compliance_result,common_name,not_after,not_before,
+            extended_key_usage,fingerprint,issuer_common_name,issuer_dn,issuer_dn_normalized,
+            issuer_serial_number,key_size,key_usage,key_uuid,public_key_algorithm,
+            public_key_fingerprint,serial_number,signature_algorithm,subject_alternative_names,
+            subject_dn,subject_dn_normalized,subject_type,trusted_ca,user_uuid)
+            VALUES (
+            :#{#cert.uuid}, :#{#cert.author}, :#{#cert.created}, :#{#cert.updated}, :#{#cert.raProfileUuid}, :#{#cert.certificateContentId},
+            :#{#cert.certificateRequestUuid}, :#{#cert.sourceCertificateUuid}, :#{#cert.issuerCertificateUuid}, :#{#cert.certificateType.name()},
+            :#{#cert.state.name()}, :#{#cert.validationStatus.name()}, :#{#cert.certificateValidationResult}, :#{#cert.statusValidationTimestamp},
+            :#{#cert.complianceStatus.name()}, :#{#cert.complianceResult}, :#{#cert.commonName}, :#{#cert.notAfter}, :#{#cert.notBefore},
+            :#{#cert.extendedKeyUsage}, :#{#cert.fingerprint}, :#{#cert.issuerCommonName}, :#{#cert.issuerDn}, :#{#cert.issuerDnNormalized},
+            :#{#cert.issuerSerialNumber}, :#{#cert.keySize}, :#{#cert.keyUsage}, :#{#cert.keyUuid}, :#{#cert.publicKeyAlgorithm},
+            :#{#cert.publicKeyFingerprint}, :#{#cert.serialNumber}, :#{#cert.signatureAlgorithm}, :#{#cert.subjectAlternativeNames},
+            :#{#cert.subjectDn}, :#{#cert.subjectDnNormalized}, :#{#cert.subjectType.name()}, :#{#cert.trustedCa}, :#{#cert.userUuid}
+            )
+            ON CONFLICT (fingerprint)
+            DO NOTHING
+            """, nativeQuery = true)
+    int insertWithFingerprintConflictResolve(@Param("cert") Certificate certificate);
 }

--- a/src/main/java/com/czertainly/core/service/CertificateService.java
+++ b/src/main/java/com/czertainly/core/service/CertificateService.java
@@ -77,6 +77,8 @@ public interface CertificateService extends ResourceExtensionService  {
 
     CertificateDetailDto upload(UploadCertificateRequestDto request, boolean ignoreCustomAttributes) throws AlreadyExistException, CertificateException, NoSuchAlgorithmException, NotFoundException, AttributeException;
 
+    Certificate createCertificateAtomic(String certificate, boolean assignOwner) throws CertificateException, NoSuchAlgorithmException, NotFoundException;
+
     // TODO AUTH - unable to check access based on certificate serial number. Make private? Special permission? Call opa in method?
     void revokeCertificate(String serialNumber);
 

--- a/src/main/resources/db/migration/V202502281641__set_certificate_content_fingerprint_unique.sql
+++ b/src/main/resources/db/migration/V202502281641__set_certificate_content_fingerprint_unique.sql
@@ -1,0 +1,3 @@
+ALTER TABLE certificate_content ADD UNIQUE (fingerprint);
+ALTER TABLE certificate_content ALTER COLUMN id SET DEFAULT nextval('certificate_content_id_seq');
+


### PR DESCRIPTION
Fix of parallel validation when competing threads try to insert same certificate downloaded from AIA extension and add to inventory at same time. That violates unique constraint that cause errors in operation.

This fix resolves conflict gracefully with atomic insert with `ON CONFLICT (fingerprint) DO NOTHING` clause in insert
and after insert loads already present certificate from DB.