### PR TITLE
Fix bulk delete of certificates

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -300,6 +300,11 @@ public class CertificateServiceImpl implements CertificateService {
     public void deleteCertificate(SecuredUUID uuid) throws NotFoundException {
         Certificate certificate = getCertificateEntity(uuid);
 
+        deleteCertificateInternal(certificate);
+    }
+
+    private void deleteCertificateInternal(Certificate certificate) throws NotFoundException {
+        SecuredUUID uuid = certificate.getSecuredUuid();
         if (certificate.getUserUuid() != null) {
             eventProducer.produceCertificateEventMessage(uuid.getValue(), CertificateEvent.DELETE.getCode(), CertificateEventStatus.FAILED.toString(), "Certificate is used by an User", null);
             throw new ValidationException("Could not delete certificate %s with UUID %s: Certificate is used by some user.".formatted(certificate.getCommonName(), certificate.getUuid().toString()));
@@ -413,16 +418,17 @@ public class CertificateServiceImpl implements CertificateService {
         if (request.getFilters() == null || request.getFilters().isEmpty() || (request.getUuids() != null && !request.getUuids().isEmpty())) {
             int deletedCount = 0;
             for (String uuid : request.getUuids()) {
-                UUID certificateUuid = UUID.fromString(uuid);
+                SecuredUUID certificateUuid = SecuredUUID.fromString(uuid);
                 try {
-                    deleteCertificate(SecuredUUID.fromUUID(certificateUuid));
+                    Certificate certificate = getCertificateEntityWithAssociations(certificateUuid);
+                    deleteCertificateInternal(certificate);
                     ++deletedCount;
                 } catch (Exception e) {
                     logger.error("Unable to delete the certificate {}: {}", certificateUuid, e.getMessage());
                     if (loggedUserUuid == null) {
                         loggedUserUuid = UUID.fromString(AuthHelper.getUserIdentification().getUuid());
                     }
-                    notificationProducer.produceNotificationText(Resource.CERTIFICATE, certificateUuid, NotificationRecipient.buildUserNotificationRecipient(loggedUserUuid), "Unable to delete the certificate " + certificateUuid, e.getMessage());
+                    notificationProducer.produceNotificationText(Resource.CERTIFICATE, certificateUuid.getValue(), NotificationRecipient.buildUserNotificationRecipient(loggedUserUuid), "Unable to delete the certificate " + certificateUuid, e.getMessage());
                 }
             }
             logger.debug("Bulk deleted {} of {} certificates.", deletedCount, request.getUuids().size());

--- a/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/CertificateServiceTest.java
@@ -384,7 +384,6 @@ class CertificateServiceTest extends BaseSpringBootTest {
     }
 
     @Test
-    @Disabled("Necessary to resolve resting of async methods")
     void testBulkRemove() throws NotFoundException {
         RemoveCertificateDto request = new RemoveCertificateDto();
         request.setUuids(List.of(certificate.getUuid().toString()));


### PR DESCRIPTION
Bulk delete certificates is run as async and non transactional and does not create session. It is necessary to load certificate with all associations because they are not lazy fetched.