### PR TITLE
Fix missing RA profile attributes in legacy client operations

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/ClientOperationServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/ClientOperationServiceImpl.java
@@ -21,6 +21,7 @@ import com.czertainly.api.model.core.authority.CertificateSignRequestDto;
 import com.czertainly.api.model.core.authority.CertificateSignResponseDto;
 import com.czertainly.api.model.core.authority.EditEndEntityRequestDto;
 import com.czertainly.api.model.core.authority.EndEntityDto;
+import com.czertainly.api.model.core.raprofile.RaProfileDto;
 import com.czertainly.core.attribute.engine.AttributeEngine;
 import com.czertainly.core.dao.entity.Certificate;
 import com.czertainly.core.dao.entity.RaProfile;
@@ -132,6 +133,8 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE)
     public void addEndEntity(String raProfileName, ClientAddEndEntityRequestDto request) throws ConnectorException {
         RaProfile raProfile = getRaProfileEntityChecked(raProfileName);
+        RaProfileDto raProfileDto = raProfile.mapToDto();
+        raProfileDto.setAttributes(attributeEngine.getObjectDataAttributesContent(raProfile.getAuthorityInstanceReference().getConnectorUuid(), null, Resource.RA_PROFILE, raProfile.getUuid()));
 
         AddEndEntityRequestDto caRequest = new AddEndEntityRequestDto();
         caRequest.setUsername(request.getUsername());
@@ -140,7 +143,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         caRequest.setSubjectDN(request.getSubjectDN());
         caRequest.setSubjectAltName(request.getSubjectAltName());
         caRequest.setExtensionData(request.getExtensionData());
-        caRequest.setRaProfile(raProfile.mapToDto());
+        caRequest.setRaProfile(raProfileDto);
 
         endEntityApiClient.createEndEntity(
                 raProfile.getAuthorityInstanceReference().getConnector().mapToDto(),
@@ -166,6 +169,8 @@ public class ClientOperationServiceImpl implements ClientOperationService {
     @ExternalAuthorization(resource = Resource.RA_PROFILE, action = ResourceAction.UPDATE)
     public void editEndEntity(String raProfileName, String username, ClientEditEndEntityRequestDto request) throws ConnectorException {
         RaProfile raProfile = getRaProfileEntityChecked(raProfileName);
+        RaProfileDto raProfileDto = raProfile.mapToDto();
+        raProfileDto.setAttributes(attributeEngine.getObjectDataAttributesContent(raProfile.getAuthorityInstanceReference().getConnectorUuid(), null, Resource.RA_PROFILE, raProfile.getUuid()));
 
         EditEndEntityRequestDto caRequest = new EditEndEntityRequestDto();
         caRequest.setPassword(request.getPassword());
@@ -174,7 +179,7 @@ public class ClientOperationServiceImpl implements ClientOperationService {
         caRequest.setSubjectAltName(request.getSubjectAltName());
         caRequest.setExtensionData(request.getExtensionData());
         caRequest.setStatus(request.getStatus());
-        caRequest.setRaProfile(raProfile.mapToDto());
+        caRequest.setRaProfile(raProfileDto);
 
         endEntityApiClient.updateEndEntity(
                 raProfile.getAuthorityInstanceReference().getConnector().mapToDto(),


### PR DESCRIPTION
When adding or editing end entity, RA profile attributes were not set to RaProfileDto send to legacy authority connector