### PR TITLE
Fix trigger association event validation

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/TriggerServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/TriggerServiceImpl.java
@@ -233,6 +233,9 @@ public class TriggerServiceImpl implements TriggerService {
             if (trigger.getResource() != event.getResource()) {
                 throw new ValidationException("Trigger '%s' is for different resource (%s) than event '%s' (%s)".formatted(trigger.getName(), trigger.getResource().getLabel(), event.getLabel(), event.getResource().getLabel()));
             }
+            if (trigger.getEvent() != null && trigger.getEvent() != event) {
+                throw new ValidationException("Trigger '%s' is for different event (%s) than event '%s'".formatted(trigger.getName(), trigger.getEvent().getLabel(), event.getLabel()));
+            }
 
             TriggerAssociation triggerAssociation = new TriggerAssociation();
             triggerAssociation.setTriggerUuid(triggerUuid);

--- a/src/test/java/com/czertainly/core/service/TriggerServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/TriggerServiceTest.java
@@ -168,6 +168,11 @@ class TriggerServiceTest extends BaseSpringBootTest {
         Assertions.assertThrows(ValidationException.class, () -> createTrigger(Resource.CERTIFICATE, null, List.of(ruleCert.getUuid()), List.of(actionCert.getUuid(), actionDisc.getUuid())), "Creating trigger with mismatching resource of actions should fail");
         Assertions.assertThrows(ValidationException.class, () -> createTrigger(Resource.CERTIFICATE, ResourceEvent.CERTIFICATE_STATUS_CHANGED, List.of(ruleCert.getUuid()), List.of(actionCert.getUuid(), actionMixed.getUuid())));
         Assertions.assertDoesNotThrow(() -> createTrigger(Resource.CERTIFICATE, ResourceEvent.CERTIFICATE_STATUS_CHANGED, List.of(ruleCert.getUuid()), List.of(actionCert.getUuid(), actionAny.getUuid())));
+
+        TriggerDto triggerWithEvent = createTrigger(Resource.CERTIFICATE, ResourceEvent.CERTIFICATE_STATUS_CHANGED, List.of(ruleCert.getUuid()), List.of(actionCert.getUuid()));
+        Assertions.assertThrows(ValidationException.class,
+                () -> triggerService.createTriggerAssociations(ResourceEvent.CERTIFICATE_EXPIRING, null, null, List.of(UUID.fromString(triggerWithEvent.getUuid())), true),
+                "Creating trigger association with mismatching event should fail");
     }
 
     private ConditionDto createCondition(Resource resource, ConditionType type) throws AlreadyExistException {


### PR DESCRIPTION
## Summary
- validate the event when associating triggers to events
- test that associating a trigger with mismatching event fails

## Testing
- `mvn -q -Dtest=TriggerServiceTest test` *(fails: Could not transfer artifact com.czertainly:dependencies:pom:1.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_685dab3de28c832d84f366135b3e1102