### PR TITLE
Fix OCSP and CRL connection timeout

### DIFF
--- a/src/main/java/com/czertainly/core/service/impl/CrlServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CrlServiceImpl.java
@@ -91,7 +91,7 @@ public class CrlServiceImpl implements CrlService {
         List<String> crlUrls = CrlUtil.getCDPFromCertificate(crlDistributionPointsEncoded);
 
         Crl crl = null;
-
+        boolean failedToRead = false;
         for (String crlUrl : crlUrls) {
             X509CRL x509CRL;
             try {
@@ -99,6 +99,7 @@ public class CrlServiceImpl implements CrlService {
             } catch (Exception e) {
                 // Failed to read content from URL, continue to next URL
                 logger.error("Failed to read CRL content from URL: {}, {}", crlUrl, e.getMessage());
+                failedToRead = true;
                 continue;
             }
 
@@ -137,6 +138,11 @@ public class CrlServiceImpl implements CrlService {
             // Managed to process a CRL url and do not need to try other URLs
             return crl;
         }
+
+        if (failedToRead) {
+            throw new IOException("Failed to read CRL from %d available URL(s)".formatted(crlUrls.size()));
+        }
+
         return crl;
     }
 

--- a/src/main/java/com/czertainly/core/util/CrlUtil.java
+++ b/src/main/java/com/czertainly/core/util/CrlUtil.java
@@ -5,6 +5,8 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x509.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -19,9 +21,14 @@ import java.security.cert.X509CRL;
 import java.util.ArrayList;
 import java.util.List;
 
+@Component
 public class CrlUtil {
-    //CRL Timeout setting when initiating URL Connection. If the connection takes more than 30 seconds, it is determined as not reachable
-    private static final Integer CRL_CONNECTION_TIMEOUT = 1000; //milliseconds
+    private static int crlConnectionTimeout; // milliseconds
+
+    @Value("${validation.crl.timeout:1000}")
+    public void setOcspConnectionTimeout(int value) {
+        crlConnectionTimeout = value;
+    }
 
     private CrlUtil() {
     }
@@ -75,8 +82,8 @@ public class CrlUtil {
         X509CRL x509Crl;
         URL url = URI.create(crlUrl).toURL();
         URLConnection connection = url.openConnection();
-        connection.setConnectTimeout(CRL_CONNECTION_TIMEOUT);
-        connection.setReadTimeout(CRL_CONNECTION_TIMEOUT);
+        connection.setConnectTimeout(crlConnectionTimeout);
+        connection.setReadTimeout(crlConnectionTimeout);
 
         try (DataInputStream inStream = new DataInputStream(connection.getInputStream())) {
             x509Crl = (X509CRL) cf.generateCRL(inStream);

--- a/src/main/java/com/czertainly/core/util/CrlUtil.java
+++ b/src/main/java/com/czertainly/core/util/CrlUtil.java
@@ -22,12 +22,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@SuppressWarnings("java:S2696")
 public class CrlUtil {
-    private static int crlConnectionTimeout; // milliseconds
+    private static int crlReadTimeout; // milliseconds
+    private static int crlConnectTimeout; // milliseconds
 
-    @Value("${validation.crl.timeout:1000}")
-    public void setOcspConnectionTimeout(int value) {
-        crlConnectionTimeout = value;
+    @Value("${validation.crl.read-timeout:1000}")
+    public void setCrlReadTimeout(int timeout) {
+        crlReadTimeout = timeout;
+    }
+
+    @Value("${validation.crl.connect-timeout:1000}")
+    public void setCrlConnectTimeout(int timeout) {
+        crlConnectTimeout = timeout;
     }
 
     private CrlUtil() {
@@ -82,8 +89,8 @@ public class CrlUtil {
         X509CRL x509Crl;
         URL url = URI.create(crlUrl).toURL();
         URLConnection connection = url.openConnection();
-        connection.setConnectTimeout(crlConnectionTimeout);
-        connection.setReadTimeout(crlConnectionTimeout);
+        connection.setConnectTimeout(crlConnectTimeout);
+        connection.setReadTimeout(crlReadTimeout);
 
         try (DataInputStream inStream = new DataInputStream(connection.getInputStream())) {
             x509Crl = (X509CRL) cf.generateCRL(inStream);

--- a/src/main/java/com/czertainly/core/util/CrlUtil.java
+++ b/src/main/java/com/czertainly/core/util/CrlUtil.java
@@ -5,12 +5,11 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x509.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.cert.CRLException;
@@ -21,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CrlUtil {
-    private static final Logger logger = LoggerFactory.getLogger(CrlUtil.class);
     //CRL Timeout setting when initiating URL Connection. If the connection takes more than 30 seconds, it is determined as not reachable
     private static final Integer CRL_CONNECTION_TIMEOUT = 1000; //milliseconds
 
@@ -74,17 +72,18 @@ public class CrlUtil {
             if (crl == null) throw new Exception("Crl not available in LDAP.");
             return (X509CRL) cf.generateCRL(new ByteArrayInputStream(crl));
         }
-        X509CRL X509Crl;
-        URL url = new URL(crlUrl);
+        X509CRL x509Crl;
+        URL url = URI.create(crlUrl).toURL();
         URLConnection connection = url.openConnection();
         connection.setConnectTimeout(CRL_CONNECTION_TIMEOUT);
+        connection.setReadTimeout(CRL_CONNECTION_TIMEOUT);
 
         try (DataInputStream inStream = new DataInputStream(connection.getInputStream())) {
-            X509Crl = (X509CRL) cf.generateCRL(inStream);
+            x509Crl = (X509CRL) cf.generateCRL(inStream);
         } catch (CRLException e) {
             throw new CertificateException("File " + e.getMessage() + " not found");
         }
-        return X509Crl;
+        return x509Crl;
     }
 
 }

--- a/src/main/java/com/czertainly/core/util/OcspUtil.java
+++ b/src/main/java/com/czertainly/core/util/OcspUtil.java
@@ -38,10 +38,12 @@ import java.util.List;
 import java.util.Map;
 
 @Component
+@SuppressWarnings("java:S2696")
 public class OcspUtil {
     private static final Logger logger = LoggerFactory.getLogger(OcspUtil.class);
 
-    private static int ocspConnectionTimeout; // milliseconds
+    private static int ocspReadTimeout; // milliseconds
+    private static int ocspConnectTimeout; // milliseconds
 
     private static final Map<Integer, String> ocspResponseStatuses = Map.of(
             OCSPResponseStatus.SUCCESSFUL, "Successful",
@@ -52,9 +54,14 @@ public class OcspUtil {
             OCSPResponseStatus.UNAUTHORIZED, "Unauthorized"
     );
 
-    @Value("${validation.ocsp.timeout:1000}")
-    public void setOcspConnectionTimeout(int value) {
-        ocspConnectionTimeout = value;
+    @Value("${validation.ocsp.read-timeout:1000}")
+    public void setOcspReadTimeout(int timeout) {
+        ocspReadTimeout = timeout;
+    }
+
+    @Value("${validation.ocsp.connect-timeout:1000}")
+    public void setOcspConnectTimeout(int timeout) {
+        ocspConnectTimeout = timeout;
     }
 
     private OcspUtil() {
@@ -157,8 +164,8 @@ public class OcspUtil {
             if (serviceUrl.startsWith("http")) {
                 URL url = URI.create(serviceUrl).toURL();
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
-                con.setConnectTimeout(ocspConnectionTimeout);
-                con.setReadTimeout(ocspConnectionTimeout);
+                con.setConnectTimeout(ocspConnectTimeout);
+                con.setReadTimeout(ocspReadTimeout);
                 con.setRequestProperty("Content-Type", "application/ocsp-request");
                 con.setRequestProperty("Accept", "application/ocsp-response");
                 con.setDoOutput(true);

--- a/src/main/java/com/czertainly/core/util/OcspUtil.java
+++ b/src/main/java/com/czertainly/core/util/OcspUtil.java
@@ -38,6 +38,8 @@ import java.util.Map;
 public class OcspUtil {
     private static final Logger logger = LoggerFactory.getLogger(OcspUtil.class);
 
+    private static final int OCSP_CONNECTION_TIMEOUT = 1000; // milliseconds
+
     private static final Map<Integer, String> ocspResponseStatuses = Map.of(
             OCSPResponseStatus.SUCCESSFUL, "Successful",
             OCSPResponseStatus.MALFORMED_REQUEST, "Malformed request",
@@ -147,6 +149,8 @@ public class OcspUtil {
             if (serviceUrl.startsWith("http")) {
                 URL url = new URL(serviceUrl);
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
+                con.setConnectTimeout(OCSP_CONNECTION_TIMEOUT);
+                con.setReadTimeout(OCSP_CONNECTION_TIMEOUT);
                 con.setRequestProperty("Content-Type", "application/ocsp-request");
                 con.setRequestProperty("Accept", "application/ocsp-response");
                 con.setDoOutput(true);

--- a/src/main/java/com/czertainly/core/util/OcspUtil.java
+++ b/src/main/java/com/czertainly/core/util/OcspUtil.java
@@ -27,11 +27,11 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.math.BigInteger;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -147,7 +147,7 @@ public class OcspUtil {
         try {
             byte[] array = request.getEncoded();
             if (serviceUrl.startsWith("http")) {
-                URL url = new URL(serviceUrl);
+                URL url = URI.create(serviceUrl).toURL();
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
                 con.setConnectTimeout(OCSP_CONNECTION_TIMEOUT);
                 con.setReadTimeout(OCSP_CONNECTION_TIMEOUT);

--- a/src/main/java/com/czertainly/core/util/OcspUtil.java
+++ b/src/main/java/com/czertainly/core/util/OcspUtil.java
@@ -23,6 +23,8 @@ import org.bouncycastle.operator.OperatorException;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.io.*;
 import java.math.BigInteger;
@@ -35,10 +37,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@Component
 public class OcspUtil {
     private static final Logger logger = LoggerFactory.getLogger(OcspUtil.class);
 
-    private static final int OCSP_CONNECTION_TIMEOUT = 1000; // milliseconds
+    private static int ocspConnectionTimeout; // milliseconds
 
     private static final Map<Integer, String> ocspResponseStatuses = Map.of(
             OCSPResponseStatus.SUCCESSFUL, "Successful",
@@ -48,6 +51,11 @@ public class OcspUtil {
             OCSPResponseStatus.SIG_REQUIRED, "Signature required",
             OCSPResponseStatus.UNAUTHORIZED, "Unauthorized"
     );
+
+    @Value("${validation.ocsp.timeout:1000}")
+    public void setOcspConnectionTimeout(int value) {
+        ocspConnectionTimeout = value;
+    }
 
     private OcspUtil() {
 
@@ -149,8 +157,8 @@ public class OcspUtil {
             if (serviceUrl.startsWith("http")) {
                 URL url = URI.create(serviceUrl).toURL();
                 HttpURLConnection con = (HttpURLConnection) url.openConnection();
-                con.setConnectTimeout(OCSP_CONNECTION_TIMEOUT);
-                con.setReadTimeout(OCSP_CONNECTION_TIMEOUT);
+                con.setConnectTimeout(ocspConnectionTimeout);
+                con.setReadTimeout(ocspConnectionTimeout);
                 con.setRequestProperty("Content-Type", "application/ocsp-request");
                 con.setRequestProperty("Accept", "application/ocsp-response");
                 con.setDoOutput(true);

--- a/src/main/java/com/czertainly/core/validation/certificate/X509CertificateValidator.java
+++ b/src/main/java/com/czertainly/core/validation/certificate/X509CertificateValidator.java
@@ -278,7 +278,7 @@ public class X509CertificateValidator implements ICertificateValidator {
         try {
             crlUuid = crlService.getCurrentCrl(certificate, issuerCertificate);
         } catch (IOException e) {
-            return new CertificateValidationCheckDto(CertificateValidationCheck.CRL_VERIFICATION, CertificateValidationStatus.FAILED, "Failed to retrieve CRL URL from certificate: " + e.getMessage());
+            return new CertificateValidationCheckDto(CertificateValidationCheck.CRL_VERIFICATION, CertificateValidationStatus.FAILED, "Failed to retrieve CRL: " + e.getMessage());
         } catch (ValidationException e) {
             return new CertificateValidationCheckDto(CertificateValidationCheck.CRL_VERIFICATION, CertificateValidationStatus.FAILED, "Failed to process CRL: " + e.getMessage());
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,3 +147,4 @@ validation:
   ocsp:
     read-timeout: 1000
     connect-timeout: 1000
+    

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -142,6 +142,8 @@ spring:
 
 validation:
   crl:
-    timeout: 2000
+    read-timeout: 2000
+    connect-timeout: 1000
   ocsp:
-    timeout: 1000
+    read-timeout: 1000
+    connect-timeout: 1000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,3 +139,9 @@ spring:
   threads:
     virtual:
       enabled: true
+
+validation:
+  crl:
+    timeout: 2000
+  ocsp:
+    timeout: 1000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,4 +147,3 @@ validation:
   ocsp:
     read-timeout: 1000
     connect-timeout: 1000
-    

--- a/src/test/java/com/czertainly/core/helpers/CertificateGeneratorHelper.java
+++ b/src/test/java/com/czertainly/core/helpers/CertificateGeneratorHelper.java
@@ -11,17 +11,23 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.cert.ocsp.*;
 import org.bouncycastle.cert.ocsp.jcajce.JcaBasicOCSPRespBuilder;
+import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.bouncycastle.jcajce.spec.SLHDSAParameterSpec;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.DigestCalculator;
 import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+import org.bouncycastle.pqc.jcajce.spec.FalconParameterSpec;
 
 import java.math.BigInteger;
 import java.security.*;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Base64;
 import java.util.Date;
@@ -110,12 +116,12 @@ public class CertificateGeneratorHelper {
     public static AlgorithmParameterSpec getDefaultParameterSpec(KeyAlgorithm algorithm) {
         return switch (algorithm) {
             case RSA -> new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4);
-            case ECDSA -> null;
-            case FALCON -> null;
-            case MLDSA -> null;
-            case SLHDSA -> null;
-            case MLKEM -> null;
-            default -> null;
+            case ECDSA -> new ECGenParameterSpec("secp521r1");
+            case FALCON -> FalconParameterSpec.falcon_1024;
+            case MLDSA -> MLDSAParameterSpec.ml_dsa_87_with_sha512;
+            case SLHDSA -> SLHDSAParameterSpec.slh_dsa_sha2_256s_with_sha512;
+            case MLKEM -> MLKEMParameterSpec.ml_kem_1024;
+            default -> throw new UnsupportedOperationException("Unsupported algorithm: " + algorithm);
         };
     }
 

--- a/src/test/java/com/czertainly/core/helpers/CertificateGeneratorHelper.java
+++ b/src/test/java/com/czertainly/core/helpers/CertificateGeneratorHelper.java
@@ -1,0 +1,175 @@
+package com.czertainly.core.helpers;
+
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import lombok.Getter;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.cert.ocsp.*;
+import org.bouncycastle.cert.ocsp.jcajce.JcaBasicOCSPRespBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DigestCalculator;
+import org.bouncycastle.operator.DigestCalculatorProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
+import java.util.Base64;
+import java.util.Date;
+
+public class CertificateGeneratorHelper {
+
+    private CertificateGeneratorHelper() {
+    }
+
+    public static CertificateChainInfo generateCertificateWithIssuer(KeyAlgorithm algorithm, String issuerDn, String subjectDn, String ocspUrl) throws Exception {
+        // Generate self-signed CA
+        KeyPair caKeyPair = generateKeyPair(algorithm, null);
+        X509Certificate caCert = generateCACertificate(caKeyPair, issuerDn);
+
+        // Generate end-entity certificate
+        KeyPair eeKeyPair = generateKeyPair(algorithm, null);
+        X509Certificate eeCert = generateEndEntityCertificate(caKeyPair, caCert, eeKeyPair, subjectDn, ocspUrl);
+
+        return new CertificateChainInfo(caKeyPair, caCert, eeKeyPair, eeCert);
+    }
+
+    public static KeyPair generateKeyPair(KeyAlgorithm algorithm, AlgorithmParameterSpec params) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm.getCode());
+        keyGen.initialize(params == null ? getDefaultParameterSpec(algorithm) : params);
+        return keyGen.generateKeyPair();
+    }
+
+    public static X509Certificate generateCACertificate(KeyPair caKeyPair, String subjectDn) throws Exception {
+        if (caKeyPair == null) {
+            caKeyPair = generateKeyPair(KeyAlgorithm.RSA, null);
+        }
+
+        X500Name issuer = new X500Name(subjectDn);
+        BigInteger serial = BigInteger.valueOf(System.currentTimeMillis());
+        Date start = new Date();
+        Date end = new Date(System.currentTimeMillis() + 3650 * 86400000L); // 10 year
+
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                issuer, serial, start, end, issuer, caKeyPair.getPublic()
+        );
+
+        // CA extensions
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA")
+                .build(caKeyPair.getPrivate());
+
+        return new JcaX509CertificateConverter()
+                .getCertificate(builder.build(signer));
+    }
+
+    public static X509Certificate generateEndEntityCertificate(
+            KeyPair caKeyPair, X509Certificate caCert, KeyPair eeKeyPair, String subjectDn, String ocspUrl) throws Exception {
+
+        X500Name issuer = new X500Name(caCert.getSubjectX500Principal().getName());
+        X500Name subject = new X500Name(subjectDn);
+        BigInteger serial = BigInteger.valueOf(System.currentTimeMillis());
+        Date start = new Date();
+        Date end = new Date(System.currentTimeMillis() + 365 * 86400000L); // 1 year
+
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                issuer, serial, start, end, subject, eeKeyPair.getPublic()
+        );
+
+        // Add OCSP AIA extension
+        if (ocspUrl != null) {
+            GeneralName ocspLocation = new GeneralName(GeneralName.uniformResourceIdentifier, ocspUrl);
+            AccessDescription ocspAccess = new AccessDescription(AccessDescription.id_ad_ocsp, ocspLocation);
+            AuthorityInformationAccess aia = new AuthorityInformationAccess(ocspAccess);
+
+            builder.addExtension(Extension.authorityInfoAccess, false, aia);
+        }
+
+        // Standard extensions
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA")
+                .build(caKeyPair.getPrivate());
+
+        return new JcaX509CertificateConverter()
+                .getCertificate(builder.build(signer));
+    }
+
+    public static AlgorithmParameterSpec getDefaultParameterSpec(KeyAlgorithm algorithm) {
+        return switch (algorithm) {
+            case RSA -> new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4);
+            case ECDSA -> null;
+            case FALCON -> null;
+            case MLDSA -> null;
+            case SLHDSA -> null;
+            case MLKEM -> null;
+            default -> null;
+        };
+    }
+
+    public static OCSPResp generateOCSPResponse(
+            X509Certificate issuerCert,
+            PrivateKey issuerKey,
+            X509Certificate certToCheck,
+            CertificateStatus status
+    ) throws Exception {
+        // Digest calculator for CertificateID
+        DigestCalculatorProvider digCalcProv = new JcaDigestCalculatorProviderBuilder().build();
+        DigestCalculator digCalc = digCalcProv.get(CertificateID.HASH_SHA1);
+
+        // Create CertificateID for the cert to check
+        CertificateID certId = new CertificateID(digCalc, new JcaX509CertificateHolder(issuerCert), certToCheck.getSerialNumber());
+
+        // Build OCSP response
+        BasicOCSPRespBuilder respBuilder = new JcaBasicOCSPRespBuilder(issuerCert.getPublicKey(), digCalc);
+
+        // Add response for the certificate
+        respBuilder.addResponse(certId, status);
+
+        // Sign the OCSP response
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").setProvider("BC").build(issuerKey);
+
+        X509CertificateHolder[] chain = { new JcaX509CertificateHolder(issuerCert) };
+        BasicOCSPResp basicResp = respBuilder.build(signer, chain, new Date());
+
+        // Wrap in OCSPResp
+        OCSPRespBuilder ocspRespBuilder = new OCSPRespBuilder();
+        return ocspRespBuilder.build(OCSPRespBuilder.SUCCESSFUL, basicResp);
+    }
+
+    @Getter
+    public static class CertificateChainInfo {
+        private final KeyPair caCertificateKeyPair;
+        private final X509Certificate caCertificate;
+
+        private final KeyPair endEntityCertificateKeyPair;
+        private final X509Certificate endEntityCertificate;
+
+        public String getCaCertificateBase64Encoded() throws CertificateEncodingException {
+            return Base64.getEncoder().encodeToString(caCertificate.getEncoded());
+        }
+
+        public String getEndEntityCertificateBase64Encoded() throws CertificateEncodingException {
+            return Base64.getEncoder().encodeToString(endEntityCertificate.getEncoded());
+        }
+
+        public CertificateChainInfo(KeyPair caCertificateKeyPair, X509Certificate caCertificate, KeyPair endEntityCertificateKeyPair, X509Certificate endEntityCertificate) {
+            this.caCertificateKeyPair = caCertificateKeyPair;
+            this.caCertificate = caCertificate;
+            this.endEntityCertificateKeyPair = endEntityCertificateKeyPair;
+            this.endEntityCertificate = endEntityCertificate;
+        }
+    }
+}

--- a/src/test/java/com/czertainly/core/helpers/CertificateGeneratorHelper.java
+++ b/src/test/java/com/czertainly/core/helpers/CertificateGeneratorHelper.java
@@ -27,7 +27,6 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECGenParameterSpec;
-import java.security.spec.ECParameterSpec;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Base64;
 import java.util.Date;

--- a/src/test/java/com/czertainly/core/service/CertificateValidationTest.java
+++ b/src/test/java/com/czertainly/core/service/CertificateValidationTest.java
@@ -357,9 +357,9 @@ public class CertificateValidationTest extends BaseSpringBootTest {
         certificateWithCrlDeltaEntity.setTrustedCa(true);
         certificateRepository.save(certificateWithCrlDeltaEntity);
 
-        // Test no CRL available
+        // Test no CRL available for existing URLs
         var validationResult = certificateService.getCertificateValidationResult(certificateWithCrlEntity.getSecuredUuid());
-        Assertions.assertEquals(CertificateValidationStatus.NOT_CHECKED, validationResult.getValidationChecks().get(CertificateValidationCheck.CRL_VERIFICATION).getStatus());
+        Assertions.assertEquals(CertificateValidationStatus.FAILED, validationResult.getValidationChecks().get(CertificateValidationCheck.CRL_VERIFICATION).getStatus());
 
         // Test CRL without the end certificate and without delta
         X509CRL emptyX509Crl = createEmptyCRL(x509CaCertificate, pair.getPrivate());

--- a/src/test/java/com/czertainly/core/service/CertificateValidationTest.java
+++ b/src/test/java/com/czertainly/core/service/CertificateValidationTest.java
@@ -2,6 +2,8 @@ package com.czertainly.core.service;
 
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.exception.ValidationException;
+import com.czertainly.api.model.client.certificate.UploadCertificateRequestDto;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.czertainly.api.model.core.authority.CertificateRevocationReason;
 import com.czertainly.api.model.core.certificate.*;
 import com.czertainly.api.model.core.connector.ConnectorStatus;
@@ -12,6 +14,7 @@ import com.czertainly.api.model.core.settings.PlatformSettingsUpdateDto;
 import com.czertainly.core.dao.entity.*;
 import com.czertainly.core.dao.entity.Certificate;
 import com.czertainly.core.dao.repository.*;
+import com.czertainly.core.helpers.CertificateGeneratorHelper;
 import com.czertainly.core.security.authz.SecuredUUID;
 import com.czertainly.core.util.BaseSpringBootTest;
 import com.czertainly.core.util.CertificateTestUtil;
@@ -31,6 +34,8 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v2CRLBuilder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.*;
+import org.bouncycastle.cert.ocsp.CertificateStatus;
+import org.bouncycastle.cert.ocsp.OCSPResp;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cms.CMSSignedData;
 import org.bouncycastle.operator.ContentSigner;
@@ -337,8 +342,36 @@ public class CertificateValidationTest extends BaseSpringBootTest {
     }
 
     @Test
-    void testCrlProcessing() throws GeneralSecurityException, OperatorCreationException, IOException, NotFoundException {
+    void testOcspValidationCheck() throws Exception {
+        var certificateChainInfo = CertificateGeneratorHelper.generateCertificateWithIssuer(KeyAlgorithm.RSA, "CN=Test-Ca", "CN=Test-EndEntity", "http://localhost:%d/ocsp".formatted(mockServer.port()));
 
+        UploadCertificateRequestDto uploadDto = new UploadCertificateRequestDto();
+        uploadDto.setCertificate(certificateChainInfo.getCaCertificateBase64Encoded());
+        certificateService.upload(uploadDto, true);
+
+        uploadDto.setCertificate(certificateChainInfo.getEndEntityCertificateBase64Encoded());
+        CertificateDetailDto certificateEndEntity = certificateService.upload(uploadDto, true);
+
+        var validationResult = certificateService.getCertificateValidationResult(SecuredUUID.fromString(certificateEndEntity.getUuid()));
+        Assertions.assertEquals(CertificateValidationStatus.FAILED, validationResult.getValidationChecks().get(CertificateValidationCheck.OCSP_VERIFICATION).getStatus());
+
+        OCSPResp ocspResp = CertificateGeneratorHelper.generateOCSPResponse(certificateChainInfo.getCaCertificate(), certificateChainInfo.getCaCertificateKeyPair().getPrivate(), certificateChainInfo.getEndEntityCertificate(), CertificateStatus.GOOD);
+        mockServer.stubFor(WireMock
+                .post(WireMock.urlPathMatching("/ocsp"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/ocsp-response")
+                        .withBody(ocspResp.getEncoded())));
+
+
+        validationResult = certificateService.getCertificateValidationResult(SecuredUUID.fromString(certificateEndEntity.getUuid()));
+        Assertions.assertEquals(CertificateValidationStatus.VALID, validationResult.getValidationChecks().get(CertificateValidationCheck.OCSP_VERIFICATION).getStatus());
+
+        mockServer.removeStubMapping(mockServer.getStubMappings().getFirst());
+    }
+
+    @Test
+    void testCrlProcessing() throws GeneralSecurityException, OperatorCreationException, IOException, NotFoundException {
         KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("RSA");
         keyPairGen.initialize(2048);
         KeyPair pair = keyPairGen.generateKeyPair();
@@ -430,8 +463,6 @@ public class CertificateValidationTest extends BaseSpringBootTest {
         Assertions.assertEquals(CertificateValidationStatus.FAILED, validationResult.getValidationChecks().get(CertificateValidationCheck.CRL_VERIFICATION).getStatus());
         Assertions.assertThrows(ValidationException.class, () -> crlService.getCurrentCrl(certificateWithDelta, certificateWithDelta));
 
-
-
         // Test deltaCrl with revoked cert and with one certificate to remove from CRL entries
         crlRepository.deleteAll();
         X509CRL deltaCrl3 = createEmptyDeltaCRL(x509CaCertificate.getSubjectX500Principal(), pair.getPrivate(), BigInteger.valueOf(Integer.parseInt(crlWithRevoked.getCrlNumber())), BigInteger.TWO);
@@ -457,7 +488,6 @@ public class CertificateValidationTest extends BaseSpringBootTest {
         crlEntryId1.setCrlUuid(crlWithDelta2Uuid);
         crlEntryId1.setSerialNumber(BigInteger.valueOf(1234).toString(16));
         Assertions.assertEquals(CertificateRevocationReason.KEY_COMPROMISE, crlEntryRepository.findById(crlEntryId1).get().getRevocationReason());
-
     }
 
 


### PR DESCRIPTION
## Summary
- add 1 second connection timeout to OCSP requests
- add read timeout to CRLUtil.getX509Crl
- fix validation check result to `Failed` when CRL URLs are present in certificate extension but content is not available

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6862a78d8210832d8096ab1113f4cb0c