### PR TITLE
Fix missing concurrency in ActionListener and make it configurable in all listeners

### DIFF
--- a/src/main/java/com/czertainly/core/messaging/listeners/ActionListener.java
+++ b/src/main/java/com/czertainly/core/messaging/listeners/ActionListener.java
@@ -19,7 +19,6 @@ import com.czertainly.core.service.ApprovalService;
 import com.czertainly.core.service.v2.ClientOperationService;
 import com.czertainly.core.util.AuthHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -33,7 +32,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Component
-@Transactional
 public class ActionListener {
     private static final Logger logger = LoggerFactory.getLogger(ActionListener.class);
 
@@ -49,8 +47,9 @@ public class ActionListener {
 
     private AuthHelper authHelper;
 
-    @RabbitListener(queues = RabbitMQConstants.QUEUE_ACTIONS_NAME, messageConverter = "jsonMessageConverter")
+    @RabbitListener(queues = RabbitMQConstants.QUEUE_ACTIONS_NAME, messageConverter = "jsonMessageConverter", concurrency = "${messaging.concurrency.actions}")
     public void processMessage(final ActionMessage actionMessage) throws MessageHandlingException {
+        logger.debug("|||Handling message");
         boolean hasApproval = actionMessage.getApprovalUuid() != null;
         boolean isApproved = hasApproval && actionMessage.getApprovalStatus().equals(ApprovalStatusEnum.APPROVED);
 

--- a/src/main/java/com/czertainly/core/messaging/listeners/ActionListener.java
+++ b/src/main/java/com/czertainly/core/messaging/listeners/ActionListener.java
@@ -49,7 +49,6 @@ public class ActionListener {
 
     @RabbitListener(queues = RabbitMQConstants.QUEUE_ACTIONS_NAME, messageConverter = "jsonMessageConverter", concurrency = "${messaging.concurrency.actions}")
     public void processMessage(final ActionMessage actionMessage) throws MessageHandlingException {
-        logger.debug("|||Handling message");
         boolean hasApproval = actionMessage.getApprovalUuid() != null;
         boolean isApproved = hasApproval && actionMessage.getApprovalStatus().equals(ApprovalStatusEnum.APPROVED);
 

--- a/src/main/java/com/czertainly/core/messaging/listeners/EventListener.java
+++ b/src/main/java/com/czertainly/core/messaging/listeners/EventListener.java
@@ -35,7 +35,7 @@ public class EventListener {
         this.eventHandlers = eventHandlers;
     }
 
-    @RabbitListener(queues = RabbitMQConstants.QUEUE_EVENTS_NAME, messageConverter = "jsonMessageConverter", concurrency = "3")
+    @RabbitListener(queues = RabbitMQConstants.QUEUE_EVENTS_NAME, messageConverter = "jsonMessageConverter", concurrency = "${messaging.concurrency.events}")
     public void processMessage(EventMessage eventMessage) {
         if (eventMessage.getUserUuid() != null) {
             authHelper.authenticateAsUser(eventMessage.getUserUuid());

--- a/src/main/java/com/czertainly/core/messaging/listeners/NotificationListener.java
+++ b/src/main/java/com/czertainly/core/messaging/listeners/NotificationListener.java
@@ -127,7 +127,7 @@ public class NotificationListener {
         this.resourceObjectAssociationService = resourceObjectAssociationService;
     }
 
-    @RabbitListener(queues = RabbitMQConstants.QUEUE_NOTIFICATIONS_NAME, messageConverter = "jsonMessageConverter")
+    @RabbitListener(queues = RabbitMQConstants.QUEUE_NOTIFICATIONS_NAME, messageConverter = "jsonMessageConverter", concurrency = "${messaging.concurrency.notifications}")
     public void processMessage(NotificationMessage message) {
         logger.debug("Received notification message: {}", message);
 

--- a/src/main/java/com/czertainly/core/messaging/listeners/SchedulerListener.java
+++ b/src/main/java/com/czertainly/core/messaging/listeners/SchedulerListener.java
@@ -25,7 +25,7 @@ public class SchedulerListener {
         this.schedulerService = schedulerService;
     }
 
-    @RabbitListener(queues = RabbitMQConstants.QUEUE_SCHEDULER_NAME, messageConverter = "jsonMessageConverter", concurrency = "10")
+    @RabbitListener(queues = RabbitMQConstants.QUEUE_SCHEDULER_NAME, messageConverter = "jsonMessageConverter", concurrency = "${messaging.concurrency.scheduler}")
     public void processMessage(SchedulerJobExecutionMessage schedulerMessage) {
         logger.debug("Received scheduler message: {}", schedulerMessage);
         try {

--- a/src/main/java/com/czertainly/core/messaging/listeners/ValidationListener.java
+++ b/src/main/java/com/czertainly/core/messaging/listeners/ValidationListener.java
@@ -24,7 +24,7 @@ public class ValidationListener {
 
     private CertificateHandler certificateHandler;
 
-    @RabbitListener(queues = RabbitMQConstants.QUEUE_VALIDATION_NAME, messageConverter = "jsonMessageConverter", concurrency = "5")
+    @RabbitListener(queues = RabbitMQConstants.QUEUE_VALIDATION_NAME, messageConverter = "jsonMessageConverter", concurrency = "${messaging.concurrency.validation}")
     public void processMessage(final ValidationMessage validationMessage) {
         List<Certificate> certificates;
         if (validationMessage.getUuids() != null) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -140,6 +140,14 @@ spring:
     virtual:
       enabled: true
 
+messaging:
+  concurrency:
+    actions: 10
+    events: 5
+    notifications: 3
+    scheduler: 10
+    validation: 5
+
 validation:
   crl:
     read-timeout: 2000


### PR DESCRIPTION
- make handler of ActionListener and client operation not running in transaction to prevent long running transactions. Only service called methods run in separate transactions.

fixes #1080 