### PR TITLE
Fix constructing ComplianceCheckResultDto and handling internal rules evaluation error

### DIFF
--- a/src/main/java/com/czertainly/core/model/compliance/ComplianceCheckContext.java
+++ b/src/main/java/com/czertainly/core/model/compliance/ComplianceCheckContext.java
@@ -3,6 +3,7 @@ package com.czertainly.core.model.compliance;
 import com.czertainly.api.clients.v2.ComplianceApiClient;
 import com.czertainly.api.exception.ConnectorException;
 import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.exception.RuleException;
 import com.czertainly.api.model.common.enums.IPlatformEnum;
 import com.czertainly.api.model.connector.compliance.v2.ComplianceResponseDto;
 import com.czertainly.api.model.connector.compliance.v2.ComplianceResponseRuleDto;
@@ -93,7 +94,7 @@ public class ComplianceCheckContext {
         }
     }
 
-    private void performSubjectComplianceCheck(ComplianceCheckProfileContext profileContext, ComplianceSubjectHandler<? extends ComplianceSubject> subjectHandler, Resource resource, ComplianceSubject subject) throws ConnectorException, NotFoundException {
+    private void performSubjectComplianceCheck(ComplianceCheckProfileContext profileContext, ComplianceSubjectHandler<? extends ComplianceSubject> subjectHandler, Resource resource, ComplianceSubject subject) throws ConnectorException, NotFoundException, RuleException {
         for (ComplianceProfileRule profileRule : profileContext.getInternalRules()) {
             // skip rules that do not match the resource and type
             if (skipProfileRule(profileRule, resource)) {

--- a/src/main/java/com/czertainly/core/model/compliance/ComplianceResultDto.java
+++ b/src/main/java/com/czertainly/core/model/compliance/ComplianceResultDto.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Setter
@@ -33,4 +34,18 @@ public class ComplianceResultDto implements Serializable {
     @Schema(description = "List of groups", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<ComplianceResultProviderRulesDto> providerRules = new ArrayList<>();
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ComplianceResultDto that = (ComplianceResultDto) o;
+        return Objects.equals(timestamp, that.timestamp)
+                && Objects.equals(message, that.message)
+                && status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, message, status);
+    }
 }

--- a/src/main/java/com/czertainly/core/service/handler/ComplianceSubjectHandler.java
+++ b/src/main/java/com/czertainly/core/service/handler/ComplianceSubjectHandler.java
@@ -51,7 +51,7 @@ public class ComplianceSubjectHandler<T extends ComplianceSubject> {
      * @param profileRule the profile rule containing the internal rule to be evaluated
      * @param subject     the subject to be evaluated
      */
-    public void evaluateInternalRule(ComplianceProfileRule profileRule, ComplianceSubject subject) {
+    public void evaluateInternalRule(ComplianceProfileRule profileRule, ComplianceSubject subject) throws RuleException {
         T typedSubject = (T) subject;
         if (wasAlreadyChecked(subject.getUuid(), null, profileRule)) {
             return;
@@ -77,8 +77,9 @@ public class ComplianceSubjectHandler<T extends ComplianceSubject> {
         try {
             valid = triggerEvaluator.evaluateInternalRule(profileRule.getInternalRule(), typedSubject);
         } catch (RuleException e) {
-            logger.debug("RuleException while evaluating internal rule {} for subject {}: {}", internalRuleUuid, subject.getUuid(), e.getMessage());
-            valid = false;
+            String message = "Failed evaluating internal rule %s: %s".formatted(profileRule.getInternalRule().getName(), e.getMessage());
+            logger.warn(message);
+            throw new RuleException(message);
         }
         if (!valid) {
             if (complianceResultDto.getInternalRules() == null) {

--- a/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
+++ b/src/main/java/com/czertainly/core/service/impl/CertificateServiceImpl.java
@@ -363,7 +363,7 @@ public class CertificateServiceImpl implements CertificateService {
 
         if (certificate.getComplianceResult() != null) {
             ComplianceCheckResultDto complianceCheckResult = complianceService.getComplianceCheckResult(Resource.CERTIFICATE, certificate.getUuid(), certificate.getComplianceResult());
-            dto.setNonCompliantRules(complianceCheckResult.getFailedRules().stream().map(failedRule -> {
+            dto.setNonCompliantRules(complianceCheckResult.getFailedRules().stream().filter(rule -> rule.getConnectorUuid() != null).map(failedRule -> {
                 CertificateComplianceResultDto resultDto = new CertificateComplianceResultDto();
                 resultDto.setConnectorName(failedRule.getConnectorName());
                 resultDto.setRuleName(failedRule.getName());

--- a/src/test/java/com/czertainly/core/service/compliance/BaseComplianceTest.java
+++ b/src/test/java/com/czertainly/core/service/compliance/BaseComplianceTest.java
@@ -73,6 +73,7 @@ class BaseComplianceTest extends BaseSpringBootTest {
 
     protected UUID internalRuleUuid;
     protected UUID internalRule2Uuid;
+    protected UUID internalRuleInvalidUuid;
     protected final UUID complianceV1RuleUuid = UUID.randomUUID();
     protected final UUID complianceV1Rule2Uuid = UUID.randomUUID();
     protected final UUID complianceV1GroupUuid = UUID.randomUUID();
@@ -98,7 +99,7 @@ class BaseComplianceTest extends BaseSpringBootTest {
         complianceProfile.setDescription("Sample Description");
         complianceProfileRepository.save(complianceProfile);
 
-        createInternalRule();
+        createInternalRules();
         createComplianceProfileAssociations();
 
         AuthorityInstanceReference authorityInstanceReference = new AuthorityInstanceReference();
@@ -154,12 +155,12 @@ class BaseComplianceTest extends BaseSpringBootTest {
         return connector;
     }
 
-    private void createInternalRule() throws AlreadyExistException {
+    private void createInternalRules() throws AlreadyExistException {
         ConditionItemRequestDto conditionItemRequestDto = new ConditionItemRequestDto();
         conditionItemRequestDto.setFieldSource(FilterFieldSource.PROPERTY);
         conditionItemRequestDto.setFieldIdentifier("KEY_SIZE");
         conditionItemRequestDto.setOperator(FilterConditionOperator.EQUALS);
-        conditionItemRequestDto.setValue(1024);
+        conditionItemRequestDto.setValue(new int[] {1024});
 
         ComplianceInternalRuleRequestDto ruleRequestDto = new ComplianceInternalRuleRequestDto();
         ruleRequestDto.setName("TestInternalRule");
@@ -173,6 +174,12 @@ class BaseComplianceTest extends BaseSpringBootTest {
         ruleRequestDto.setName("TestInternalRule2");
         ruleDetailDto = complianceProfileService.createComplianceInternalRule(ruleRequestDto);
         internalRule2Uuid = ruleDetailDto.getUuid();
+
+        conditionItemRequestDto.setFieldIdentifier("UNKNOWN_FIELD");
+        conditionItemRequestDto.setValue(true);
+        ruleRequestDto.setName("TestInternalRuleInvalid");
+        ruleDetailDto = complianceProfileService.createComplianceInternalRule(ruleRequestDto);
+        internalRuleInvalidUuid = ruleDetailDto.getUuid();
     }
 
     private void createComplianceProfileAssociations() {

--- a/src/test/java/com/czertainly/core/service/compliance/ComplianceServiceTest.java
+++ b/src/test/java/com/czertainly/core/service/compliance/ComplianceServiceTest.java
@@ -54,6 +54,13 @@ class ComplianceServiceTest extends BaseComplianceTest {
 
     @Test
     void testCheckCompliance() throws Exception {
+        var internalRuleAssoc = new ComplianceProfileRule();
+        internalRuleAssoc.setComplianceProfile(complianceProfile);
+        internalRuleAssoc.setComplianceProfileUuid(complianceProfile.getUuid());
+        internalRuleAssoc.setResource(Resource.CERTIFICATE);
+        internalRuleAssoc.setInternalRuleUuid(internalRuleInvalidUuid);
+        complianceProfileRuleRepository.save(internalRuleAssoc);
+
         // add a V1 provider rule association to the seeded compliance profile
         var v1RuleAssoc = new ComplianceProfileRule();
         v1RuleAssoc.setComplianceProfile(complianceProfile);
@@ -154,6 +161,15 @@ class ComplianceServiceTest extends BaseComplianceTest {
         certificate.setComplianceResult(complianceResult);
         certificate.setRaProfileUuid(associatedRaProfileUuid);
         certificateRepository.save(certificate);
+        complianceService.checkCompliance(uuids, Resource.CERTIFICATE, null);
+
+        // check failed compliance with invalid internal rule and V1 and V2 provider rules
+        complianceCheckResult = complianceService.getComplianceCheckResult(Resource.CERTIFICATE, certificate.getUuid());
+        Assertions.assertEquals(ComplianceStatus.FAILED, complianceCheckResult.getStatus(), "Compliance result status should be Failed");
+        Assertions.assertNotNull(complianceCheckResult.getMessage());
+
+        complianceProfileRuleRepository.delete(internalRuleAssoc);
+
         complianceService.checkCompliance(uuids, Resource.CERTIFICATE, null);
         complianceCheckResult = complianceService.getComplianceCheckResult(Resource.CERTIFICATE, certificate.getUuid());
         Assertions.assertEquals(ComplianceStatus.NOK, complianceCheckResult.getStatus(), "Compliance result status should be Not Compliant");


### PR DESCRIPTION
- fix removing rules UUIDs from compliance result to avoid mutating rule lists when determining compliance rule status
- filter internal rules when setting deprecated non-compliant rules of certificate DTO
- when internal rule evaluation throws exception, set compliance result to FAILED instead marking rule as Not Compliant